### PR TITLE
Corrected bookmarks context menu padding

### DIFF
--- a/BringBackTheContextIcons/chrome.css
+++ b/BringBackTheContextIcons/chrome.css
@@ -443,7 +443,7 @@ menuitem[id="placesContext_new:separator"] {
 }
 
 :not(:not(menubar) > menu, #ContentSelectDropdown)
-  > menupopup:not(#toolbar-context-menu)
+  > menupopup:not(#placesContext[needsgutter]):not(#toolbar-context-menu)
   > menuitem:not(
     .menuitem-iconic,
     [type="checkbox"],
@@ -453,7 +453,7 @@ menuitem[id="placesContext_new:separator"] {
     .unified-nav-current
   ),
 :not(:not(menubar) > menu, #ContentSelectDropdown)
-  > menupopup:not(#toolbar-context-menu)
+  > menupopup:not(#placesContext[needsgutter]):not(#toolbar-context-menu)
   > menu:not(
     .menu-iconic,
     [type="checkbox"],
@@ -462,11 +462,22 @@ menuitem[id="placesContext_new:separator"] {
     .in-menulist menu,
     .unified-nav-current
   ),
-:not(:not(menubar) > menu, #ContentSelectDropdown) > menupopup > menucaption {
+:not(:not(menubar) > menu, #ContentSelectDropdown) > menupopup:not(
+  #placesContext[needsgutter]) > menucaption, 
+  menupopup#toolbar-context-menu > menupopup,
+  menupopup#toolbar-context-menu > menuitem,
+  menupopup#toolbar-context-menu > menu {
   padding-inline-start: calc(
     var(--zen-contextmenu-menuitem-padding-inline) +
       var(--zen-contextmenu-menuicon-margin-inline) / 2
   ) !important; /* Default: approx 30px */
+}
+
+/* Adds correct padding for bookmarks context menu */
+menupopup#placesContext[needsgutter] > menupopup,
+menupopup#placesContext[needsgutter] > menuitem,
+menupopup#placesContext[needsgutter] > menu {
+  padding-inline-start: 5px !important;
 }
 
 /* Linux-specific adjustment for menucaption padding based on user feedback */


### PR DESCRIPTION
This fixes an issue where the bookmarks context menu had extra padding between the icons and labels compared to other context menus. Thanks for making this!

Old:
<img height="500" alt="Screenshot_576" src="https://github.com/user-attachments/assets/09e4f940-410f-430b-9e3a-c000c730dbbe" />

New:
<img height="500" alt="Screenshot_577" src="https://github.com/user-attachments/assets/f0e5b576-bedf-49fb-b1ff-15373941d464" />